### PR TITLE
List the current version in drop-down menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@
                           <span class="sr-only">Toggle Dropdown</span>
                         </button>
                         <div class="dropdown-menu dropdown-menu-right">
+                          <h6 class="dropdown-header">Current Version</h6>
+                          <a href="https://download.cheribsd.org/releases/arm64/aarch64c/22.12/cheribsd-memstick-arm64-aarch64c-22.12.img.xz"
+                             class="dropdown-item">22.12</a>
                           <h6 class="dropdown-header">Old Versions</h6>
                           <a href="https://download.cheribsd.org/releases/arm64/aarch64c/22.05p1/cheribsd-memstick-arm64-aarch64c-22.05p1.img.xz"
                              class="dropdown-item">22.05p1</a>
@@ -97,6 +100,9 @@
                           <span class="sr-only">Toggle Dropdown</span>
                         </button>
                         <div class="dropdown-menu dropdown-menu-right">
+                          <h6 class="dropdown-header">Current Version</h6>
+                          <a href="/release-notes/22.12/index.html"
+                             class="dropdown-item">22.12</a>
                           <h6 class="dropdown-header">Old Versions</h6>
                           <a href="/release-notes/22.05p1/index.html"
                              class="dropdown-item">22.05p1</a>


### PR DESCRIPTION
In case a user clicks an arrow for a drop-down menu, they might be confused that it does not list the current version and they might assume the link is missing.