### PR TITLE
Use GitHub Pages to host CheriBSD.org

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -1,0 +1,20 @@
+name: Remove old artifacts
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at 1am
+    - cron: '0 1 * * *'
+
+jobs:
+  remove-old-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Remove old artifacts
+      uses: c-hive/gha-remove-artifacts@v1
+      with:
+        age: '1 month'
+        skip-tags: true
+        skip-recent: 10

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,111 @@
+name: Build website
+
+on:
+  push:
+    branches-ignore:
+      - gh-pages
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: website
+          path: .
+
+  draft-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: website
+          path: cheribsd-website-snapshot
+
+      - name: Create archive
+        run: zip -r cheribsd-website-snapshot-${{ github.sha }}.zip cheribsd-website-snapshot
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date -u +'%Y%m%d')"
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: draft-${{ steps.date.outputs.date }}-${{ github.sha }}
+          release_name: Draft release ${{ steps.date.outputs.date }}
+          body: Latest snapshot (${{ github.sha }})
+          prerelease: true
+
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: cheribsd-website-snapshot-${{ github.sha }}.zip
+          asset_name: cheribsd-website-snapshot-${{ github.sha }}.zip
+          asset_content_type: application/zip
+
+  release:
+    if: github.event_name == 'release' && github.event.action == 'created'
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: website
+          path: cheribsd-website-${{ github.event.release.tag_name }}
+
+      - name: Create archive
+        run: zip -r cheribsd-website-${{ github.event.release.tag_name }}.zip cheribsd-website-${{ github.event.release.tag_name }}
+
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: cheribsd-website-${{ github.event.release.tag_name }}.zip
+          asset_name: cheribsd-website-${{ github.event.release.tag_name }}.zip
+          asset_content_type: application/zip
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: website
+          path: public
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "getting-started/23.11"]
+	path = getting-started/23.11
+	url = https://github.com/CTSRD-CHERI/cheribsd-getting-started.git
+	branch = gh-pages

--- a/index.html
+++ b/index.html
@@ -133,6 +133,22 @@
                       </div>
                     </div>
                   </div>
+                  <div class="row">
+                    <div class="col">
+                      <div class="btn-group mb-3 w-100">
+                        <a href="./tutorial/23.11/"
+                           class="btn btn-outline-primary w-100">View Tutorial</a>
+                        <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
+                          <span class="sr-only">Toggle Dropdown</span>
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right">
+                          <h6 class="dropdown-header">Current Version</h6>
+                          <a href="./tutorial/23.11/"
+                             class="dropdown-item">23.11</a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
                 <div class="col d-md-none d-lg-block">
                   <div class="row">

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
     <title>CheriBSD</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="/assets/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="./assets/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png">
+    <link rel="manifest" href="./site.webmanifest">
     <meta name="msapplication-TileColor" content="#b91d47">
   </head>
   <body>
@@ -36,7 +36,7 @@
       <div class="navbar navbar-dark bg-dark shadow-sm">
         <div class="container d-flex justify-content-between">
           <a href="#" class="navbar-brand d-flex align-items-center">
-            <img src="/CHERI.svg" width="30" height="30" class="mr-1">
+            <img src="./CHERI.svg" width="30" height="30" class="mr-1">
             <strong>CheriBSD</strong>
           </a>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation">
@@ -103,21 +103,21 @@
                   <div class="row">
                     <div class="col">
                       <div class="btn-group mb-3 w-100">
-                        <a href="/release-notes/23.11/index.html"
+                        <a href="./release-notes/23.11/index.html"
                            class="btn btn-outline-primary w-100">View Release Notes</a>
                         <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
                           <span class="sr-only">Toggle Dropdown</span>
                         </button>
                         <div class="dropdown-menu dropdown-menu-right">
                           <h6 class="dropdown-header">Current Version</h6>
-                          <a href="/release-notes/23.11/index.html"
+                          <a href="./release-notes/23.11/index.html"
                              class="dropdown-item">23.11</a>
                           <h6 class="dropdown-header">Old Versions</h6>
-                          <a href="/release-notes/22.12/index.html"
+                          <a href="./release-notes/22.12/index.html"
                              class="dropdown-item">22.12</a>
-                          <a href="/release-notes/22.05p1/index.html"
+                          <a href="./release-notes/22.05p1/index.html"
                              class="dropdown-item">22.05p1</a>
-                          <a href="/release-notes/22.05/index.html"
+                          <a href="./release-notes/22.05/index.html"
                              class="dropdown-item">22.05</a>
                         </div>
                       </div>
@@ -180,5 +180,5 @@
     </footer>
   </body>
   <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script>window.jQuery || document.write('<script src="assets/js/vendor/jquery.slim.min.js"><\/script>')</script><script src="assets/dist/js/bootstrap.bundle.min.js"></script>
+  <script>window.jQuery || document.write('<script src="./assets/js/vendor/jquery.slim.min.js"><\/script>')</script><script src="./assets/dist/js/bootstrap.bundle.min.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -73,8 +73,18 @@
                 <div class="col-md-6 col-lg-12">
                   <div class="row">
                     <div class="col">
-                      <a href="https://ctsrd-cheri.github.io/cheribsd-getting-started/cover/index.html"
-                        class="btn btn-primary w-100 mb-3">Get Started on Morello</a>
+                      <div class="btn-group mb-3 w-100">
+                        <a href="getting-started/23.11/"
+                          class="btn btn-primary w-100">Get Started on Morello</a>
+                        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
+                          <span class="sr-only">Toggle Dropdown</span>
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right">
+                          <h6 class="dropdown-header">Current Version</h6>
+                          <a href="getting-started/23.11/"
+                             class="dropdown-item">23.11</a>
+                        </div>
+                      </div>
                     </div>
                   </div>
                   <div class="row">

--- a/release-notes/22.05/index.html
+++ b/release-notes/22.05/index.html
@@ -6,12 +6,12 @@
     <title>CheriBSD 22.05 Release Notes</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="/assets/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../../assets/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../../favicon-16x16.png">
+    <link rel="manifest" href="../../site.webmanifest">
     <meta name="msapplication-TileColor" content="#b91d47">
   </head>
   <body>

--- a/release-notes/22.05p1/index.html
+++ b/release-notes/22.05p1/index.html
@@ -6,12 +6,12 @@
     <title>CheriBSD 22.05p1 Release Notes</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="/assets/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../../assets/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../../favicon-16x16.png">
+    <link rel="manifest" href="../../site.webmanifest">
     <meta name="msapplication-TileColor" content="#b91d47">
   </head>
   <body>

--- a/release-notes/22.12/index.html
+++ b/release-notes/22.12/index.html
@@ -6,12 +6,12 @@
     <title>CheriBSD 22.12 Release Notes</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="/assets/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../../assets/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../../favicon-16x16.png">
+    <link rel="manifest" href="../../site.webmanifest">
     <meta name="msapplication-TileColor" content="#b91d47">
   </head>
   <body>

--- a/release-notes/23.11/index.html
+++ b/release-notes/23.11/index.html
@@ -6,12 +6,12 @@
     <title>CheriBSD 23.11 Release Notes</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="/assets/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../../assets/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../../favicon-16x16.png">
+    <link rel="manifest" href="../../site.webmanifest">
     <meta name="msapplication-TileColor" content="#b91d47">
   </head>
   <body>


### PR DESCRIPTION
This PR is still work in progress. The goal is to:
* Use GitHub Pages to host this website
* Include Getting Started with CheriBSD guide versions under /getting-started/ using GitHub Pages generated by cheribsd-getting-started
* Include Tutorial versions under /tutorial/ using GitHub Pages generated by cheribsd-tutorial

This is currently blocked by https://github.com/CTSRD-CHERI/cheribsd-getting-started/pull/55.